### PR TITLE
Initialize open-research-nexus monorepo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Node
+node_modules
+.pnpm
+pnpm-lock.yaml
+npm-debug.log*
+yarn.lock
+
+# Rust
+target/
+Cargo.lock
+**/*.rs.bk
+
+# Terraform
+*.tfstate
+*.tfstate.*
+.terraform/
+.terraform.lock.hcl

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 open-research-nexus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,1 @@
-# RESEARCH-IN
-a free, global hub that ingests every serious PDF, dataset, hypothesis, and experiment, then makes them instantly searchable, discussable, and remix‑able—so no human ever re‑does solved work. UX must feel as clean as Google Search and as sticky/social as Reddit or Lemmy.
+Open Research Nexus is a turborepo for collaborative research tools.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@open-research-nexus/web",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "15.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <div>Hello from Next.js 15</div>;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "open-research-nexus",
+  "private": true,
+  "workspaces": [
+    "apps/*",
+    "services/*",
+    "packages/*"
+  ]
+}

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -1,0 +1,1 @@
+export const greeting = 'Hello from shared';

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@open-research-nexus/shared",
+  "version": "0.0.0",
+  "main": "index.ts",
+  "types": "index.ts",
+  "private": true
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - 'apps/*'
+  - 'services/*'
+  - 'packages/*'

--- a/services/ingest/Cargo.toml
+++ b/services/ingest/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "ingest"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/services/ingest/src/main.rs
+++ b/services/ingest/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Ingest service running");
+}


### PR DESCRIPTION
## Summary
- set up pnpm workspaces for `open-research-nexus`
- add Next.js web app, Rust ingest service, and shared package
- configure editor settings, gitignore, and MIT license
- add minimal README and example code

## Testing
- `pnpm -v`
- `cargo --version`


------
https://chatgpt.com/codex/tasks/task_e_684a04a47c4083268c48f01a652044bf