### PR TITLE
Fix Terraform provider download in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,6 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2
       - name: Terraform Init (no backend)
-        run: terraform -chdir=infra/terraform init -backend=false -input=false
+        run: terraform -chdir=infra/terraform init -backend=false -input=false -upgrade
       - name: Terraform Validate
         run: terraform -chdir=infra/terraform validate -no-color

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,3 @@ Cargo.lock
 *.tfstate
 *.tfstate.*
 .terraform/
-.terraform.lock.hcl


### PR DESCRIPTION
## Summary
- enable `terraform init` to download providers in CI
- track `.terraform.lock.hcl` by removing it from `.gitignore`

## Testing
- `terraform -chdir=infra/terraform validate -no-color` *(fails: missing providers)*

------
https://chatgpt.com/codex/tasks/task_e_684a0a8b45888326bd82b38e12999324