### PR TITLE
Add command palette and search API

### DIFF
--- a/apps/web/src/app/api/search/route.ts
+++ b/apps/web/src/app/api/search/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { rrfMerge } from '@open-research-nexus/shared';
+
+const TYPESENSE_URL = process.env.TYPESENSE_URL ?? '';
+const QDRANT_URL = process.env.QDRANT_URL ?? '';
+
+async function queryTypesense(q: string) {
+  if (!TYPESENSE_URL) return [] as any[];
+  const res = await fetch(`${TYPESENSE_URL}/search?q=${encodeURIComponent(q)}`);
+  const data = await res.json();
+  return data.hits?.map((h: any) => ({ id: h.document.id, title: h.document.title })) ?? [];
+}
+
+async function queryQdrant(q: string) {
+  if (!QDRANT_URL) return [] as any[];
+  const res = await fetch(`${QDRANT_URL}/search`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: q })
+  });
+  const data = await res.json();
+  return data.result?.map((r: any) => ({ id: r.payload.id, title: r.payload.title })) ?? [];
+}
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const q = searchParams.get('q') ?? '';
+  if (!q) return NextResponse.json([]);
+
+  const [keywordHits, semanticHits] = await Promise.all([
+    queryTypesense(q),
+    queryQdrant(q)
+  ]);
+
+  const merged = rrfMerge([keywordHits, semanticHits], 60).slice(0, 20);
+  return NextResponse.json(merged);
+}

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+
+export default function CommandPalette() {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<any[]>([]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.key === 'k' || e.key === 'K') && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        setOpen(prev => !prev);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  useEffect(() => {
+    if (!query) { setResults([]); return; }
+    const controller = new AbortController();
+    fetch(`/api/search?q=${encodeURIComponent(query)}`, { signal: controller.signal })
+      .then(res => res.json())
+      .then(setResults)
+      .catch(() => {});
+    return () => controller.abort();
+  }, [query]);
+
+  if (!open) return null;
+  return (
+    <div style={{position:'fixed',inset:0,background:'rgba(0,0,0,0.3)'}}>
+      <div style={{background:'white',margin:'10% auto',padding:20,width:400}}>
+        <input
+          autoFocus
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+          placeholder="Search"
+          style={{width:'100%'}}
+        />
+        <ul>
+          {results.map((r:any) => (
+            <li key={r.id}>{r.title || r.id}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -5,5 +5,14 @@
     "apps/*",
     "services/*",
     "packages/*"
-  ]
+  ],
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "jest": "^30.0.0",
+    "ts-jest": "^29.3.4",
+    "typescript": "^5.8.3"
+  },
+  "scripts": {
+    "test": "jest"
+  }
 }

--- a/packages/shared/__tests__/rrf.test.ts
+++ b/packages/shared/__tests__/rrf.test.ts
@@ -1,0 +1,9 @@
+import { rrfMerge } from '../rrf';
+
+test('rrfMerge merges rankings with k=60', () => {
+  const listA = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+  const listB = [{ id: 'b' }, { id: 'c' }, { id: 'a' }];
+  const result = rrfMerge([listA, listB], 60);
+  const ids = result.slice(0,3).map(r => r.id);
+  expect(ids).toEqual(['b','a','c']);
+});

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -1,1 +1,2 @@
 export const greeting = 'Hello from shared';
+export * from './rrf';

--- a/packages/shared/rrf.ts
+++ b/packages/shared/rrf.ts
@@ -1,0 +1,25 @@
+export interface DocumentWithId {
+  id: string | number;
+  [key: string]: any;
+}
+
+export function rrfMerge(lists: DocumentWithId[][], k = 60): DocumentWithId[] {
+  const scores = new Map<string | number, number>();
+  const docs = new Map<string | number, DocumentWithId>();
+
+  for (const list of lists) {
+    for (let i = 0; i < list.length; i++) {
+      const doc = list[i];
+      const id = doc.id;
+      const score = 1 / (k + i + 1);
+      scores.set(id, (scores.get(id) || 0) + score);
+      if (!docs.has(id)) {
+        docs.set(id, doc);
+      }
+    }
+  }
+
+  return Array.from(scores.entries())
+    .sort((a, b) => b[1] - a[1])
+    .map(([id]) => docs.get(id)!)
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist"
+  },
+  "include": ["**/*.ts", "**/*.tsx"]
+}


### PR DESCRIPTION
## Summary
- implement a simple command palette component that opens with Cmd/Ctrl‑K and queries `/api/search`
- create `/api/search` route that merges Typesense and Qdrant results using reciprocal-rank-fusion
- expose RRF algorithm in shared package
- add Jest unit test verifying the merge logic
- configure Jest and TypeScript for the monorepo

## Testing
- `pnpm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684a125668e083268bd3eb09a0746d3e