### PR TITLE
Scaffold ingest service in Rust

### DIFF
--- a/services/ingest/Cargo.toml
+++ b/services/ingest/Cargo.toml
@@ -1,6 +1,3 @@
-[package]
-name = "ingest"
-version = "0.1.0"
-edition = "2021"
-
-[dependencies]
+[workspace]
+members = ["core", "cli"]
+resolver = "2"

--- a/services/ingest/cli/Cargo.toml
+++ b/services/ingest/cli/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "ingest-cli"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+ingest-core = { path = "../core" }
+tokio = { version = "1", features = ["full"] }

--- a/services/ingest/cli/src/main.rs
+++ b/services/ingest/cli/src/main.rs
@@ -1,0 +1,14 @@
+use std::env;
+use std::path::PathBuf;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 3 || args[1] != "watch" {
+        eprintln!("Usage: ingest watch <ipfs-cid-file>");
+        std::process::exit(1);
+    }
+
+    let file = PathBuf::from(&args[2]);
+    ingest_core::watch(file).await
+}

--- a/services/ingest/core/Cargo.toml
+++ b/services/ingest/core/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "ingest-core"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+reqwest = { version = "0.11", features = ["json", "multipart"] }
+rust-ipfs = "0.9"
+qdrant-client = "1"
+apache-tika-server-client = "0.2"
+sentence-transformers = { version = "0.1", default-features = false, features = ["all-mpnet-base-v2", "burn-tch"] }
+md5 = "0.7"

--- a/services/ingest/core/src/lib.rs
+++ b/services/ingest/core/src/lib.rs
@@ -1,0 +1,33 @@
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use tokio::fs;
+use tokio::io::AsyncReadExt;
+use tokio::time::sleep;
+
+/// Watch the given file for new IPFS CIDs and process them.
+pub async fn watch(file: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+    let mut seen = HashSet::new();
+    loop {
+        let mut data = String::new();
+        if let Ok(mut f) = fs::File::open(&file).await {
+            f.read_to_string(&mut data).await?;
+            for cid in data.lines() {
+                if seen.insert(cid.to_string()) {
+                    process_cid(cid).await?;
+                }
+            }
+        }
+        sleep(Duration::from_secs(5)).await;
+    }
+}
+
+async fn process_cid(_cid: &str) -> Result<(), Box<dyn std::error::Error>> {
+    // 1. Download from IPFS
+    // 2. Extract text using Apache Tika
+    // 3. Split into ~500-token chunks
+    // 4. Compute embeddings using sentence-transformers
+    // 5. POST paper row and embeddings to Qdrant and Supabase
+    Ok(())
+}

--- a/services/ingest/src/main.rs
+++ b/services/ingest/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Ingest service running");
-}


### PR DESCRIPTION
## Summary
- scaffold a Rust ingest service workspace with `core` and `cli`
- implement a basic CLI command `watch <ipfs-cid-file>`
- outline async CID watching logic in core crate

## Testing
- `cargo check` *(fails: no matching package named `apache-tika-server-client` found)*

------
https://chatgpt.com/codex/tasks/task_e_684a1263d5b0832693494d3bd6c600ea