### PR TITLE
Add Lighthouse CI and OWASP ZAP checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,3 +15,32 @@ jobs:
         run: terraform -chdir=infra/terraform init -backend=false -input=false -upgrade
       - name: Terraform Validate
         run: terraform -chdir=infra/terraform validate -no-color
+
+  audit:
+    runs-on: ubuntu-latest
+    needs: terraform
+    env:
+      DEPLOY_URL: ${{ env.DEPLOY_URL }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+      - name: Build web
+        run: pnpm --filter ./apps/web build
+      - name: Lighthouse CI
+        run: |
+          pnpm --filter ./apps/web start -- -p 3000 &
+          SERVER_PID=$!
+          sleep 10
+          npx lighthouse-ci http://localhost:3000 --score=95
+          kill $SERVER_PID
+      - name: OWASP ZAP Baseline
+        run: |
+          docker run --rm -v $(pwd):/zap/wrk/:rw -t ghcr.io/zaproxy/zaproxy:stable zap-baseline.py -t $DEPLOY_URL -m 0 -r zap.html


### PR DESCRIPTION
## Summary
- run Lighthouse CI against the local build and require a score of at least 95
- run OWASP ZAP baseline scan on `$DEPLOY_URL`

## Testing
- `pnpm install`
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a12a71c148326b17897e836f5bba2