### PR TITLE
Add ORCID validation utility and secure community auth

### DIFF
--- a/apps/community/src/index.ts
+++ b/apps/community/src/index.ts
@@ -1,6 +1,8 @@
 import express from 'express';
 import jwt from 'jsonwebtoken';
-import { userWeight } from '@open-research-nexus/utils/priority';
+import { isValidOrcid, userWeight } from '@open-research-nexus/utils';
+
+const JWT_SECRET = process.env.JWT_SECRET || 'development-secret';
 
 const app = express();
 app.use(express.json());
@@ -10,7 +12,7 @@ function auth(req: express.Request, res: express.Response, next: express.NextFun
   const token = req.headers.authorization?.split(' ')[1];
   if (!token) return res.sendStatus(401);
   try {
-    (req as any).user = jwt.verify(token, 'secret');
+    (req as any).user = jwt.verify(token, JWT_SECRET);
     next();
   } catch {
     res.sendStatus(401);
@@ -20,7 +22,7 @@ function auth(req: express.Request, res: express.Response, next: express.NextFun
 // ORCID validation middleware
 function validateOrcid(req: express.Request, res: express.Response, next: express.NextFunction) {
   const orcid = req.body.orcid as string;
-  if (!/^\d{4}-\d{4}-\d{4}-\d{4}$/.test(orcid)) {
+  if (typeof orcid !== 'string' || !isValidOrcid(orcid)) {
     return res.status(400).json({ error: 'Invalid ORCID format' });
   }
   next();

--- a/apps/community/tsconfig.json
+++ b/apps/community/tsconfig.json
@@ -8,6 +8,7 @@
     "skipLibCheck": true,
     "baseUrl": ".",
     "paths": {
+      "@open-research-nexus/utils": ["../../packages/utils/index.ts"],
       "@open-research-nexus/utils/*": ["../../packages/utils/*"]
     }
   },

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -1,0 +1,2 @@
+export * from './priority';
+export * from './orcid';

--- a/packages/utils/orcid.ts
+++ b/packages/utils/orcid.ts
@@ -1,0 +1,20 @@
+const ORCID_PATTERN = /^\d{4}-\d{4}-\d{4}-\d{3}[\dX]$/;
+
+/**
+ * Validate an ORCID using the ISO 7064 mod 11-2 checksum algorithm.
+ *
+ * More info: https://info.orcid.org/faq/what-is-an-orcid-identifier/
+ */
+export function isValidOrcid(orcid: string): boolean {
+  if (!ORCID_PATTERN.test(orcid)) return false;
+
+  const digits = orcid.replace(/-/g, '').split('');
+  const checkDigit = digits.pop();
+
+  const total = digits.reduce((acc, digit) => (acc + Number(digit)) * 2, 0);
+  const remainder = total % 11;
+  const result = (12 - remainder) % 11;
+  const expected = result === 10 ? 'X' : String(result);
+
+  return checkDigit === expected;
+}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-research-nexus/utils",
   "version": "0.0.1",
-  "main": "priority.ts",
-  "types": "priority.ts"
+  "main": "index.ts",
+  "types": "index.ts"
 }


### PR DESCRIPTION
## Summary
- add an ORCID checksum validator to the shared utils package and export it via a package index
- update the community service to validate ORCID inputs with the helper and use an environment-based JWT secret
- align the community TypeScript config with the new utils entry point

## Testing
- pnpm --filter community build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69493b7dbc4c8326bc30c1a50931d039)